### PR TITLE
Fix/multi address listening bug

### DIFF
--- a/newsfragments/863.bugfix.rst
+++ b/newsfragments/863.bugfix.rst
@@ -1,0 +1,5 @@
+Fix multi-address listening bug in swarm.listen()
+
+- Fix early return in swarm.listen() that prevented listening on all addresses
+- Add comprehensive tests for multi-address listening functionality
+- Ensure all available interfaces are properly bound and connectable


### PR DESCRIPTION
## What was wrong?

The `swarm.listen()` method in `libp2p/network/swarm.py` had a bug where it would return `True` after successfully starting to listen on the first address, preventing it from trying to listen on the remaining addresses. This meant that when `get_available_interfaces()` returned multiple addresses (e.g., 192.168.1.17, 10.156.233.51, 127.0.0.1), only the first address would actually start listening.

**Symptoms:**
- Applications claimed to be listening on multiple interfaces
- `netstat` showed only one socket was actually bound
- Connections to other addresses failed with "unable to connect" errors
- Multi-interface peer-to-peer connectivity was broken

## How was it fixed?

**Root Cause:** The `listen()` method had an early `return True` statement that exited after the first successful listen, preventing subsequent addresses from being processed.

**Solution:** Modified the `listen()` method to:
1. Track success count instead of returning immediately
2. Continue trying all addresses in the loop
3. Return success if at least one address worked (maintaining original contract)

**Testing:** Added comprehensive tests in `tests/core/network/test_swarm.py`:
- `test_swarm_listen_multiple_addresses`: Validates all interfaces are listening
- `test_swarm_listen_multiple_addresses_connectivity`: Tests real libp2p connections to all addresses

**Result:** Now all available network interfaces are properly bound and connectable, enabling full multi-interface peer-to-peer networking.

### To-Do

- [x] Fix the core bug in `swarm.listen()` method
- [x] Add comprehensive tests for multi-address listening
- [x] Ensure all linting standards are met
- [x] Clean up commit history
- [x] Add entry to the [release notes](https://github.com/libp2p/py-libp2p/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![A cute penguin fixing network connections](https://images.unsplash.com/photo-1551986782-d0169b3f8fa7?w=400&h=300&fit=crop&crop=center)


